### PR TITLE
Fix false positive broken link reports

### DIFF
--- a/.github/workflows/check-humanstxt.yml
+++ b/.github/workflows/check-humanstxt.yml
@@ -32,11 +32,12 @@ jobs:
           for url in "${URLS[@]}"; do
             echo "Checking: $url"
             response_code=$(curl -o /dev/null -w "%{http_code}" \
-                      --max-time 15 \
+                      --max-time 30 \
                       --silent \
                       --location \
                       --retry 3 \
                       --retry-delay 5 \
+                      --retry-all-errors \
                       -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
                       -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" \
                       -H "Accept-Language: en-US,en;q=0.9" \


### PR DESCRIPTION
Add `--retry-all-errors` so curl retries connection failures (status `000`), not just HTTP errors. Increase timeout from 15s to 30s.

Fixes #42